### PR TITLE
ISSUE #5 concat `ensure` broken in Puppet 3.2.4

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -81,7 +81,6 @@ class asterisk::config (
 
     # Default settings for all config files created with concat
     Concat {
-      ensure => present,
       owner  => 'root',
       group  => 'asterisk',
       mode   => '0440',


### PR DESCRIPTION
The use of `Concat { ensure => present }` is broken in Puppet
3.2.4. Essentially, it was included to be pedantic. Removing.
