### PR TITLE
concat `warn` adds '#' characters by default

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -94,8 +94,7 @@ class asterisk::config (
       owner  => 'root',
       group  => 'asterisk',
       mode   => '0440',
-      warn   => true,
-      notify => Service['asterisk']
+      notify => Service['asterisk'],
     }
 
     # Manager/AMI configuration


### PR DESCRIPTION
Concat `warn` adds '#' characters by default when specyfing the `true`
boolean value. Specifying the string is not giving expected
results. Remove the parameter.
