### PR TITLE
Add support for extensions.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -180,44 +180,92 @@
 #   String. When acting as TLS client, whether asterisk should verify the server certificate 'yes' or 'no'
 #   Default: 'no'
 #
+# ==== extension.conf Options
+# [*ext_static*]
+#   String. If 'no' or omitted, then the pbx_config will rewrite the
+#     extensions.conf file when extensions are modified.
+#   Default: 'yes'
+#
+#   CAUTION: Changing to 'no' may have unpredictable results when configuring with Puppet.
+#
+# [*ext_writeprotect*]
+#   String. If static=yes and writeprotect=no, you can save dialplan
+#     by CLI command "dialplan save" in the extensions.conf file.
+#   Default: 'yes'
+#
+#   CAUTION: Changing to 'no' may have unpredictable results when configuring with Puppet.
+#
+# [*ext_autofallthrough*]
+#   String. If an extention runs out of things to do, wait 'yes' or terminate 'no'
+#   Default: 'yes' (strongly recommended)
+#
+# [*ext_patternmatchnew*]
+#   String. Beta feature for new patern matching behavior for extensions.
+#   Default: 'no'
+#
+# [*ext_clearglobalvars*]
+#   String.  Clear global variables on a dialplan reload or Asterisk reload.
+#   Default: 'no'
+#
+# [*ext_userscontext*]
+#   String. Context is where entries from users.conf are registered
+#   Default: 'default'
+#
+# [*ext_includes*]
+#   Array of Strings. Specify paths of files to `#include` in the
+#     extensions.conf file.
+#   Default: []
+#
+# [*ext_execs*]
+#   Array of Strings. Execute a program(s) or script that produces config files
+#   Default: []
+#
 class asterisk(
-  $service_enable      = $asterisk::params::service_enable,
-  $service_ensure      = $asterisk::params::service_ensure,
-  $service_manage      = $asterisk::params::service_manage,
-  $package_ensure      = $asterisk::params::package_ensure,
-  $package_name        = $asterisk::params::package_name,
-  $manage_config       = $asterisk::params::manage_config,
-  $ari_enabled         = $asterisk::params::ari_enabled,
-  $ast_dumpcore        = $asterisk::params::ast_dumpcore,
-  $astetcdir           = $asterisk::params::astetcdir,
-  $astmoddir           = $asterisk::params::astmoddir,
-  $astvarlibdir        = $asterisk::params::astvarlibdir,
-  $astdbdir            = $asterisk::params::astdbdir,
-  $astkeydir           = $asterisk::params::astkeydir,
-  $astdatadir          = $asterisk::params::astdatadir,
-  $astagidir           = $asterisk::params::astagidir,
-  $astspooldir         = $asterisk::params::astspooldir,
-  $astrundir           = $asterisk::params::astrundir,
-  $astlogdir           = $asterisk::params::astlogdir,
-  $http_enabled        = $asterisk::params::http_enabled,
-  $http_bindaddr       = $asterisk::params::http_bindaddr,
-  $http_port           = $asterisk::params::http_port,
-  $manager_bindaddr    = $asterisk::params::manager_bindaddr,
-  $manager_enabled     = $asterisk::params::manager_enabled,
-  $manager_port        = $asterisk::params::manager_port,
-  $manager_webenabled  = $asterisk::params::manager_webenabled,
-  $rtpstart            = $asterisk::params::rtpstart,
-  $rtpend              = $asterisk::params::rtpend,
-  $udpbindaddr         = $asterisk::params::udpbindaddr,
-  $tcpenable           = $asterisk::params::tcpenable,
-  $tcpbindaddr         = $asterisk::params::tcpbindaddr,
-  $tlsenable           = $asterisk::params::tlsenable,
-  $tlsbindaddr         = $asterisk::params::tlsbindaddr,
-  $tlscertfile         = $asterisk::params::tlscertfile,
-  $tlsprivatekey       = $asterisk::params::tlsprivatekey,
-  $tlscafile           = $asterisk::params::tlscafile,
-  $tlscapath           = $asterisk::params::tlscapath,
-  $tlsdontverifyserver = $asterisk::params::tlsdontverifyserver,
+  $service_enable           = $asterisk::params::service_enable,
+  $service_ensure           = $asterisk::params::service_ensure,
+  $service_manage           = $asterisk::params::service_manage,
+  $package_ensure           = $asterisk::params::package_ensure,
+  $package_name             = $asterisk::params::package_name,
+  $manage_config            = $asterisk::params::manage_config,
+  $ari_enabled              = $asterisk::params::ari_enabled,
+  $ast_dumpcore             = $asterisk::params::ast_dumpcore,
+  $astetcdir                = $asterisk::params::astetcdir,
+  $astmoddir                = $asterisk::params::astmoddir,
+  $astvarlibdir             = $asterisk::params::astvarlibdir,
+  $astdbdir                 = $asterisk::params::astdbdir,
+  $astkeydir                = $asterisk::params::astkeydir,
+  $astdatadir               = $asterisk::params::astdatadir,
+  $astagidir                = $asterisk::params::astagidir,
+  $astspooldir              = $asterisk::params::astspooldir,
+  $astrundir                = $asterisk::params::astrundir,
+  $astlogdir                = $asterisk::params::astlogdir,
+  $http_enabled             = $asterisk::params::http_enabled,
+  $http_bindaddr            = $asterisk::params::http_bindaddr,
+  $http_port                = $asterisk::params::http_port,
+  $manager_bindaddr         = $asterisk::params::manager_bindaddr,
+  $manager_enabled          = $asterisk::params::manager_enabled,
+  $manager_port             = $asterisk::params::manager_port,
+  $manager_webenabled       = $asterisk::params::manager_webenabled,
+  $rtpstart                 = $asterisk::params::rtpstart,
+  $rtpend                   = $asterisk::params::rtpend,
+  $udpbindaddr              = $asterisk::params::udpbindaddr,
+  $tcpenable                = $asterisk::params::tcpenable,
+  $tcpbindaddr              = $asterisk::params::tcpbindaddr,
+  $tlsenable                = $asterisk::params::tlsenable,
+  $tlsbindaddr              = $asterisk::params::tlsbindaddr,
+  $tlscertfile              = $asterisk::params::tlscertfile,
+  $tlsprivatekey            = $asterisk::params::tlsprivatekey,
+  $tlscafile                = $asterisk::params::tlscafile,
+  $tlscapath                = $asterisk::params::tlscapath,
+  $tlsdontverifyserver      = $asterisk::params::tlsdontverifyserver,
+  $ext_static               = $asterisk::params::ext_static,
+  $ext_writeprotect         = $asterisk::params::ext_writeprotect,
+  $ext_autofallthrough      = $asterisk::params::ext_autofallthrough,
+  $ext_patternmatchnew      = $asterisk::params::ext_patternmatchnew,
+  $ext_clearglobalvars      = $asterisk::params::ext_clearglobalvars,
+  $ext_userscontext         = $asterisk::params::ext_userscontext,
+  $ext_includes             = $asterisk::params::ext_includes,
+  $ext_execs                = $asterisk::params::ext_execs,
 ) inherits asterisk::params {
 
   validate_string($package_ensure, $package_name)
@@ -227,6 +275,9 @@ class asterisk(
   validate_string($udpbindaddr, $tcpenable, $tcpbindaddr)
   validate_string($tlsenable, $tlsbindaddr, $tlscertfile)
   validate_string($tlsprivatekey, $tlscafile, $tlscapath, $tlsdontverifyserver)
+  validate_string($ext_writeprotect, $ext_autofallthrough, $ext_patternmatchnew)
+  validate_string($ext_static, $ext_clearglobalvars, $ext_userscontext)
+  validate_array($ext_includes, $ext_execs)
 
   class { '::asterisk::install':
     package_ensure  => $package_ensure,
@@ -265,6 +316,14 @@ class asterisk(
     tlscafile           => $tlscafile,
     tlscapath           => $tlscapath,
     tlsdontverifyserver => $tlsdontverifyserver,
+    ext_static          => $ext_static,
+    ext_writeprotect    => $ext_writeprotect,
+    ext_autofallthrough => $ext_autofallthrough,
+    ext_patternmatchnew => $ext_patternmatchnew,
+    ext_clearglobalvars => $ext_clearglobalvars,
+    ext_userscontext    => $ext_userscontext,
+    ext_includes        => $ext_includes,
+    ext_execs           => $ext_execs,
   }  ->
   class { '::asterisk::service':
     service_ensure => $service_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,4 +72,14 @@ class asterisk::params {
       warning("OS ${::osfamily} default paths for ast*dir pramaters not provided.")
     }
   }
+
+  # Extensions configuration
+  $ext_static = 'yes'
+  $ext_writeprotect = 'yes'
+  $ext_autofallthrough = 'yes'
+  $ext_patternmatchnew = 'no'
+  $ext_clearglobalvars = 'no'
+  $ext_userscontext = 'default'
+  $ext_includes = []
+  $ext_execs = []
 }

--- a/templates/extensions.conf.general.erb
+++ b/templates/extensions.conf.general.erb
@@ -1,0 +1,123 @@
+; This file is managed by Puppet. Modify at your own risk.
+;
+; extensions.conf - the Asterisk dial plan
+;
+; Static extension configuration file, used by
+; the pbx_config module. This is where you configure all your
+; inbound and outbound calls in Asterisk.
+;
+; This configuration file is reloaded
+; - With the "dialplan reload" command in the CLI
+; - With the "reload" command (that reloads everything) in the CLI
+
+;
+; The "General" category is for certain variables.
+;
+[general]
+;
+; If static is set to no, or omitted, then the pbx_config will rewrite
+; this file when extensions are modified.  Remember that all comments
+; made in the file will be lost when that happens.
+;
+; XXX Not yet implemented XXX
+;
+static=<%= @ext_static || 'yes' %>
+;
+; if static=yes and writeprotect=no, you can save dialplan by
+; CLI command "dialplan save" too
+;
+writeprotect=<%= @ext_writeprotect || 'yes' %>
+;
+; If autofallthrough is set, then if an extension runs out of
+; things to do, it will terminate the call with BUSY, CONGESTION
+; or HANGUP depending on Asterisk's best guess. This is the default.
+;
+; If autofallthrough is not set, then if an extension runs out of
+; things to do, Asterisk will wait for a new extension to be dialed
+; (this is the original behavior of Asterisk 1.0 and earlier).
+;
+autofallthrough=<%= @ext_autofallthrough || 'yes' %>
+;
+;
+;
+; If extenpatternmatchnew is set (true, yes, etc), then a new algorithm that uses
+; a Trie to find the best matching pattern is used. In dialplans
+; with more than about 20-40 extensions in a single context, this
+; new algorithm can provide a noticeable speedup.
+; With 50 extensions, the speedup is 1.32x
+; with 88 extensions, the speedup is 2.23x
+; with 138 extensions, the speedup is 3.44x
+; with 238 extensions, the speedup is 5.8x
+; with 438 extensions, the speedup is 10.4x
+; With 1000 extensions, the speedup is ~25x
+; with 10,000 extensions, the speedup is 374x
+; Basically, the new algorithm provides a flat response
+; time, no matter the number of extensions.
+;
+; By default, the old pattern matcher is used.
+;
+; ****This is a new feature! *********************
+; The new pattern matcher is for the brave, the bold, and
+; the desperate. If you have large dialplans (more than about 50 extensions
+; in a context), and/or high call volume, you might consider setting
+; this value to "yes" !!
+; Please, if you try this out, and are forced to return to the
+; old pattern matcher, please report your reasons in a bug report
+; on https://issues.asterisk.org. We have made good progress in providing
+; something compatible with the old matcher; help us finish the job!
+;
+; This value can be switched at runtime using the cli command "dialplan set extenpatternmatchnew true"
+; or "dialplan set extenpatternmatchnew false", so you can experiment to your hearts content.
+;
+;extenpatternmatchnew=no
+extenpatternmatchnew=<%= @ext_patternmatchnew || 'no' %>
+;
+; If clearglobalvars is set, global variables will be cleared
+; and reparsed on a dialplan reload, or Asterisk reload.
+;
+; If clearglobalvars is not set, then global variables will persist
+; through reloads, and even if deleted from the extensions.conf or
+; one of its included files, will remain set to the previous value.
+;
+; NOTE: A complication sets in, if you put your global variables into
+; the AEL file, instead of the extensions.conf file. With clearglobalvars
+; set, a "reload" will often leave the globals vars cleared, because it
+; is not unusual to have extensions.conf (which will have no globals)
+; load after the extensions.ael file (where the global vars are stored).
+; So, with "reload" in this particular situation, first the AEL file will
+; clear and then set all the global vars, then, later, when the extensions.conf
+; file is loaded, the global vars are all cleared, and then not set, because
+; they are not stored in the extensions.conf file.
+;
+clearglobalvars=<%= @ext_clearglobalvars || 'no' %>
+;
+; User context is where entries from users.conf are registered.  The
+; default value is 'default'
+;
+userscontext=<%= @ext_userscontext || 'default' %>
+;
+; You can include other config files, use the #include command
+; (without the ';'). Note that this is different from the "include" command
+; that includes contexts within other contexts. The #include command works
+; in all asterisk configuration files.
+;#include "filename.conf"
+;#include <filename.conf>
+;#include filename.conf
+<% Array(@ext_includes).each do |i| -%>
+#include <%= i %>
+<% end -%>
+
+; You can execute a program or script that produces config files, and they
+; will be inserted where you insert the #exec command. The #exec command
+; works on all asterisk configuration files.  However, you will need to
+; activate them within asterisk.conf with the "execincludes" option.  They
+; are otherwise considered a security risk.
+;#exec /opt/bin/build-extra-contexts.sh
+;#exec /opt/bin/build-extra-contexts.sh --foo="bar"
+;#exec </opt/bin/build-extra-contexts.sh --foo="bar">
+;#exec "/opt/bin/build-extra-contexts.sh --foo=\"bar\""
+;
+<% Array(@ext_execs).each do |e| -%>
+exec <%= e %>
+<% end -%>
+

--- a/tests/extensions.pp
+++ b/tests/extensions.pp
@@ -1,0 +1,38 @@
+# Test the manager user configuration
+node default {
+  class { '::asterisk':
+    service_manage   => true,
+    service_ensure   => 'running',
+    tcpenable        => 'yes',
+    manage_config    => true,
+    manager_enabled  => 'yes',
+    ext_writeprotect => 'yes',
+    ext_includes     => ['extensions.d/*.conf',],
+  }
+
+  $extensions_d = '/etc/asterisk/extensions.d'
+  file{$extensions_d:
+    ensure  => directory,
+    owner   => 'asterisk',
+    group   => 'asterisk',
+    mode    => '0750',
+    recurse => true,
+  }->
+  file {"${extensions_d}/adhearsion.conf":
+    owner   => 'asterisk',
+    group   => 'asterisk',
+    mode    => '0640',
+    content => '[adhearsion]
+exten       => _.,1,AGI(agi:async)
+
+[adhearsion-redirect]
+exten       => 1,1,AGI(agi:async)',
+    notify  => Service['asterisk']
+  }
+
+  # Add an AMI user
+  ::asterisk::config::user{'/etc/asterisk/manager.conf':
+    user    => 'manager_user',
+    secret  => 'manager_secret',
+  }
+}


### PR DESCRIPTION
Starting with the [general] section, add support for the extensions.conf
file. Because we use concat, an integrator can always add
concat::fragment resources to append or prepend info to this file.

Cleaned up the path references for $astetcdir.

Explicitly stated, `false` for contact warn, as it's still leaving its fingerprints in config files...
