### PR TITLE
OpenBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ This module has been built and tested with Puppet 2.7.
 The module has been tested on:
 * Debian 7 (Wheezy)
 * Ubuntu 14.04 (Trusty)
+* OpenBSD 5.6 -current with Puppet 3.7.3
 
 ##Tests
 

--- a/manifests/config/device.pp
+++ b/manifests/config/device.pp
@@ -25,8 +25,8 @@
 #  manuals for sip devices.
 #
 define asterisk::config::device (
-  $device_name = $title,
   $target,
+  $device_name = $title,
   $type = 'friend',
   $accountcode = '',
   $allow = [],

--- a/manifests/config/device.pp
+++ b/manifests/config/device.pp
@@ -145,6 +145,6 @@ define asterisk::config::device (
   concat::fragment{"sip_device_${device_name}":
     target  => $target,
     content => template('asterisk/device.erb'),
-    order   => 50,
+    order   => '50',
   }
 }

--- a/manifests/config/user.pp
+++ b/manifests/config/user.pp
@@ -89,6 +89,6 @@ define asterisk::config::user (
   concat::fragment{$safe_title:
     target  => $target,
     content => template('asterisk/user.erb'),
-    order   => 20
+    order   => '20'
   }
 }

--- a/manifests/config/user.pp
+++ b/manifests/config/user.pp
@@ -67,15 +67,15 @@
 #     }
 #     # Add an ARI user
 #     asterisk::config::user{'/etc/asterisk/ari.conf':
-#         user   => hiera('asterisk::ari::user','ari_user),
+#         user   => hiera('asterisk::ari::user','ari_user'),
 #         secret => hiera('asterisk::ari::secret','ari_secret'),}
 #
 define asterisk::config::user (
-  $target      = $title,
   $user,
-  $secret      = "",
-  $read        = "",
-  $write       = "",
+  $target      = $title,
+  $secret      = '',
+  $read        = '',
+  $write       = '',
   $deny        = [],
   $permit      = [],
   $eventfilter = [],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,14 @@
 #   Boolean. Whether Puppet should manage the configuration files.
 #   Default: true
 #
+# [*asteriskuser*]
+#   String. The user that runs the asterisk service.
+#   Default: OS specific
+#
+# [*asteriskgroup*]
+#   String. The group that runs the asterisk service.
+#   Default: OS specific
+#
 # [*ari_enabled*]
 #   String. Enable the ARI interface in Asterisk.
 #   Options: 'yes', 'no'
@@ -60,6 +68,10 @@
 # [*ast_dumpcore*]
 #   String. Whether Asterisk should create core dumps ('no' is false, anything else is true)
 #   Default: 'no'
+#
+# [*astbinary*]
+#   String. Pointing to the 'asterisk' binary.
+#   Default: OS specific
 #
 # [*astetcdir*]
 #   String. Directory configuration option in asterisk.conf
@@ -221,6 +233,8 @@
 #   Default: []
 #
 class asterisk(
+  $asteriskuser             = $asterisk::params::asteriskuser,
+  $asteriskgroup            = $asterisk::params::asteriskgroup,
   $service_enable           = $asterisk::params::service_enable,
   $service_ensure           = $asterisk::params::service_ensure,
   $service_manage           = $asterisk::params::service_manage,
@@ -229,6 +243,7 @@ class asterisk(
   $manage_config            = $asterisk::params::manage_config,
   $ari_enabled              = $asterisk::params::ari_enabled,
   $ast_dumpcore             = $asterisk::params::ast_dumpcore,
+  $astbinary                = $asterisk::params::astbinary,
   $astetcdir                = $asterisk::params::astetcdir,
   $astmoddir                = $asterisk::params::astmoddir,
   $astvarlibdir             = $asterisk::params::astvarlibdir,
@@ -280,13 +295,16 @@ class asterisk(
   validate_array($ext_includes, $ext_execs)
 
   class { '::asterisk::install':
-    package_ensure  => $package_ensure,
-    package_name    => $package_name,
+    package_ensure => $package_ensure,
+    package_name   => $package_name,
   } ->
   class { '::asterisk::config':
     manage_config       => $manage_config,
+    asteriskuser        => $asteriskuser,
+    asteriskgroup       => $asteriskgroup,
     ari_enabled         => $ari_enabled,
     ast_dumpcore        => $ast_dumpcore,
+    astbinary           => $astbinary,
     astetcdir           => $astetcdir,
     astmoddir           => $astmoddir,
     astvarlibdir        => $astvarlibdir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,7 +42,10 @@ class asterisk::params {
 
   case $::osfamily {
     'Debian': {
+      $asteriskuser = 'asterisk'
+      $asteriskgroup = 'asterisk'
       $astetcdir = '/etc/asterisk'
+      $astbinary = '/usr/sbin/asterisk'
       $astmoddir = '/usr/lib/asterisk/modules'
       $astvarlibdir = '/var/lib/asterisk'
       $astdbdir ='/var/lib/asterisk'
@@ -54,6 +57,9 @@ class asterisk::params {
       $astlogdir = '/var/log/asterisk'
     }
     'RedHat': {
+      $asteriskuser = 'asterisk'
+      $asteriskgroup = 'asterisk'
+      $astbinary = '/usr/sbin/asterisk'
       $astetcdir = '/etc/asterisk'
       $astmoddir = $::architecture ? {
         /64/ => '/usr/lib64/asterisk/modules',
@@ -64,6 +70,21 @@ class asterisk::params {
       $astkeydir = '/var/lib/asterisk'
       $astdatadir = '/var/lib/asterisk'
       $astagidir = '/var/lib/asterisk/agi-bin'
+      $astspooldir = '/var/spool/asterisk'
+      $astrundir = '/var/run/asterisk'
+      $astlogdir = '/var/log/asterisk'
+    }
+    'OpenBSD': {
+      $asteriskuser = '_asterisk'
+      $asteriskgroup = '_asterisk'
+      $astbinary = '/usr/sbin/asterisk'
+      $astetcdir = '/etc/asterisk'
+      $astmoddir = '/usr/local/lib/asterisk/modules'
+      $astvarlibdir = '/usr/local/share/asterisk'
+      $astkeydir = '/etc/asterisk'
+      $astdbdir = '/var/db/asterisk'
+      $astdatadir = '/usr/local/share/asterisk'
+      $astagidir = '/usr/local/share/asterisk/agi-bin'
       $astspooldir = '/var/spool/asterisk'
       $astrundir = '/var/run/asterisk'
       $astlogdir = '/var/log/asterisk'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,7 +77,7 @@ class asterisk::params {
     'OpenBSD': {
       $asteriskuser = '_asterisk'
       $asteriskgroup = '_asterisk'
-      $astbinary = '/usr/sbin/asterisk'
+      $astbinary = '/usr/local/sbin/asterisk'
       $astetcdir = '/etc/asterisk'
       $astmoddir = '/usr/local/lib/asterisk/modules'
       $astvarlibdir = '/usr/local/share/asterisk'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -27,9 +27,9 @@ class asterisk::service (
       enable     => $service_enable,
       hasstatus  => true,
       hasrestart => true,
-      restart    => '/etc/init.d/asterisk restart',
-      start      => '/etc/init.d/asterisk start',
-      stop       => '/etc/init.d/asterisk stop',
+#      restart    => '/etc/init.d/asterisk restart',
+#      start      => '/etc/init.d/asterisk start',
+#      stop       => '/etc/init.d/asterisk stop',
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -27,9 +27,6 @@ class asterisk::service (
       enable     => $service_enable,
       hasstatus  => true,
       hasrestart => true,
-#      restart    => '/etc/init.d/asterisk restart',
-#      start      => '/etc/init.d/asterisk start',
-#      stop       => '/etc/init.d/asterisk stop',
     }
   }
 }


### PR DESCRIPTION
The main part of this patch is getting the module to support managing asterisk on OpenBSD.
Tested on OpenBSD 5.6-current, with asterisk-11.14.1, and puppet-3.7.3.

While there, and because I run the future parser, there are some enhancements making the module work with the future parser. Additionally to that, a few minor changes, which puppet-lint told me about.

The most "drastic" change is in manifests/service.pp, in the service, I removed the fairly unportable, start, stop and restart parameters. The service type should be clever enough to figure that out on its own, at least it does so on OpenBSD ;)

Other changes is the introduction of general parameters: asteriskuser, asteriskgroup, which contain the username/groupname of the account running asterisk. Then the astbinary, which points to the 'asterisk' binary location. Further, the group 'root' in config.pp was changed to just the userid: 0.
On OpenBSD, and other *BSD, there is no group root', but group wheel, with gid 0.

please review and apply, or comment, so I can fix or rework as you like.

Sebastian
