### PR TITLE
Enhance SIP device management to also be able to manage IAX devices.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -120,6 +120,16 @@ class asterisk::config (
       order   => '40',
     }
 
+    # IAX configuration
+    concat {"${astetcdir}/iax.conf":
+      notify => Exec['asterisk-iax-reload'],
+    }
+    concat::fragment { 'iax_general':
+      target  => "${astetcdir}/iax.conf",
+      content => template('asterisk/iax.conf.erb'),
+      order   => '10',
+    }
+
     # Manager/AMI configuration
     concat { "${astetcdir}/manager.conf": }
     concat::fragment { 'manager_header':
@@ -163,6 +173,12 @@ class asterisk::config (
   # Ask Asterisk to reload the SIP configuration
   exec { 'asterisk-sip-reload':
     command     => "${astbinary} -rx 'sip reload'",
+    refreshonly => true,
+  }
+
+  # Ask Asterisk to reload the IAX configuration
+  exec { 'asterisk-iax-reload':
+    command     => "${astbinary} -rx 'reload chan_iax2.so'",
     refreshonly => true,
   }
 }

--- a/manifests/config/device.pp
+++ b/manifests/config/device.pp
@@ -1,6 +1,6 @@
 # == Defined Type: asterisk::config::device
-#  Define SIP devices for use with Asterisk using concat::fragment on
-#  the sip.conf file.
+#  Define SIP and IAX devices for use with Asterisk using concat::fragment on
+#  the sip.conf, or iax.conf file.
 #
 # === Parameters
 #  [*device_name*]
@@ -22,7 +22,7 @@
 #
 # ==== String Parameters
 #  The remaining parameters are strings as described in the Asterisk
-#  manuals for sip devices.
+#  manuals for sip or iax devices.
 #
 define asterisk::config::device (
   $target,
@@ -97,6 +97,7 @@ define asterisk::config::device (
   $useclientcode = '',
   $username = '',
   $videosupport = '',
+  $requirecalltoken = '',
 )
 {
   validate_array ($allow, $disallow)
@@ -142,7 +143,7 @@ define asterisk::config::device (
     }
   }
 
-  concat::fragment{"sip_device_${device_name}":
+  concat::fragment{"device_${device_name}":
     target  => $target,
     content => template('asterisk/device.erb'),
     order   => '50',

--- a/templates/device.erb
+++ b/templates/device.erb
@@ -207,3 +207,6 @@ username = <%= @username %>
 <% if @videosupport != "" -%>
 videosupport = <%= @videosupport %>
 <% end -%>
+<% if @requirecalltoken != "" -%>
+requirecalltoken = <%= @requirecalltoken %>
+<% end -%>

--- a/templates/iax.conf.erb
+++ b/templates/iax.conf.erb
@@ -1,0 +1,483 @@
+;
+; Inter-Asterisk eXchange v2 (IAX2) Channel Driver configuration
+;
+; This configuration is read when the chan_iax2.so module is loaded, and is
+; re-read when the module is reloaded, such as when invoking the CLI command:
+;
+;     *CLI> iax2 reload
+;
+
+; General settings, like port number to bind to, and an option address (the
+; default is to bind to all local addresses).
+
+[general]
+
+; Listener Addresses
+;
+; Use the 'bindaddr' and 'bindport' options to specify on which address and port
+; the IAX2 channel driver will listen for incoming requests.
+;
+;
+
+;bindport=4569           ; The default port to listen on
+                         ; NOTE: bindport must be specified BEFORE bindaddr or
+                         ; may be specified on a specific bindaddr if followed by
+                         ; colon and port (e.g. bindaddr=192.168.0.1:4569)
+
+;bindaddr=192.168.0.1    ; You can specify 'bindaddr' more than once to bind to
+                         ; multiple addresses, but the first will be the
+                         ; default.
+
+;
+; Set 'iaxcompat' to yes if you plan to use layered switches or some other
+; scenario which may cause some delay when doing a lookup in the dialplan. It
+; incurs a small performance hit to enable it. This option causes Asterisk to
+; spawn a separate thread when it receives an IAX2 DPREQ (Dialplan Request)
+; instead of blocking while it waits for a response.
+;
+; Accepted values: yes, no
+; Default value:   no
+;
+;iaxcompat=yes
+;
+
+;
+; Disable UDP checksums (if nochecksums is set, then no checkums will
+; be calculated/checked on systems supporting this feature)
+;
+; Accepted values: yes, no
+; Default value:   no
+;
+;nochecksums=yes
+;
+
+;
+; For increased security against brute force password attacks enable
+; 'delayreject' which will delay the sending of authentication reject for REGREQ
+; or AUTHREP if there is a password.
+;
+; Accepted values: yes, no
+; Default value:   no
+;
+;delayreject=yes
+;
+
+;
+; You may specify a global default AMA flag for iaxtel calls.  These flags are
+; used in the generation of call detail records.
+;
+; Accepted values: default, omit, billing, documentation
+; Default value:   default
+;
+;amaflags=billing
+;
+
+;
+; ADSI (Analog Display Services Interface) can be enabled if you have (or may
+; have) ADSI compatible CPE equipment.
+;
+; Accepted values: yes, no
+; Default value:   no
+;
+;adsi=yes
+;
+
+;
+; Whether or not to perform an SRV lookup on outbound calls.
+;
+; Accepted values: yes, no
+; Default value:   no
+;
+;srvlookup=yes
+;
+
+;
+; You may specify a default account for Call Detail Records (CDRs) in addition to
+; specifying on a per-user basis.
+;
+; Accepted values: Any string value up to 19 characters in length
+; Default value:   <empty>
+;
+;accountcode=lss0101
+;
+
+;
+; You may specify a global default language for users.  This can be specified
+; also on a per-user basis.  If omitted, will fallback to English (en).
+;
+; Accepted values: A language tag such as 'en' or 'es'
+; Default value:   en
+;
+;language=en
+;
+
+;
+; This option specifies a preference for which music-on-hold class this channel
+; should listen to when put on hold if the music class has not been set on the
+; channel with Set(CHANNEL(musicclass)=whatever) in the dialplan, and the peer
+; channel putting this one on hold did not suggest a music class.
+;
+; If this option is set to "passthrough", then the hold message will always be
+; passed through as signalling instead of generating hold music locally.
+;
+; This option may be specified globally, or on a per-user or per-peer basis.
+;
+; Accepted values: passthrough, or any music-on-hold class name
+; Default value:   <empty>
+;
+;mohinterpret=default
+;
+
+;
+; The 'mohsuggest' option specifies which music on hold class to suggest to the
+; peer channel when this channel places the peer on hold. It may be specified
+; globally or on a per-user or per-peer basis.
+;
+;mohsuggest=default
+;
+
+;
+; Specify bandwidth of low, medium, or high to control which codecs are used
+; in general.
+;
+bandwidth=low
+;
+
+;
+; You can also fine tune codecs here using "allow" and "disallow" clauses with
+; specific codecs.  Use "all" to represent all formats.
+;
+;allow=all
+;disallow=g723.1
+disallow=lpc10
+;allow=gsm
+;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Jitter Buffer
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;
+; You can adjust several parameters relating to the jitter buffer.  The jitter
+; buffer's function is to compensate for varying network delay.
+;
+; All of the jitter buffer settings are in milliseconds.  The jitter buffer
+; works for INCOMING audio only - the outbound audio will be dejittered by the
+; jitter buffer at the other end.
+;
+; jitterbuffer=yes|no: global default as to whether you want
+; the jitter buffer at all.
+;
+; forcejitterbuffer=yes|no: in the ideal world, when we bridge VoIP channels
+; we don't want to do jitterbuffering on the switch, since the endpoints
+; can each handle this.  However, some endpoints may have poor jitterbuffers
+; themselves, so this option will force * to always jitterbuffer, even in this
+; case.
+;
+; maxjitterbuffer: a maximum size for the jitter buffer.
+; Setting a reasonable maximum here will prevent the call delay
+; from rising to silly values in extreme situations; you'll hear
+; SOMETHING, even though it will be jittery.
+;
+; resyncthreshold: when the jitterbuffer notices a significant change in delay
+; that continues over a few frames, it will resync, assuming that the change in
+; delay was caused by a timestamping mix-up. The threshold for noticing a
+; change in delay is measured as twice the measured jitter plus this resync
+; threshold.
+; Resyncing can be disabled by setting this parameter to -1.
+;
+; maxjitterinterps: the maximum number of interpolation frames the jitterbuffer
+; should return in a row. Since some clients do not send CNG/DTX frames to
+; indicate silence, the jitterbuffer will assume silence has begun after
+; returning this many interpolations. This prevents interpolating throughout
+; a long silence.
+;
+; jittertargetextra: number of milliseconds by which the new jitter buffer
+; will pad its size. the default is 40, so without modification, the new
+; jitter buffer will set its size to the jitter value plus 40 milliseconds.
+; increasing this value may help if your network normally has low jitter,
+; but occasionally has spikes.
+;
+
+jitterbuffer=no
+forcejitterbuffer=no
+;maxjitterbuffer=1000
+;maxjitterinterps=10
+;resyncthreshold=1000
+;jittertargetextra=40
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; IAX2 Encryption
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;
+; Enable IAX2 encryption.  The default is no.
+;
+;encryption=yes
+;
+
+;
+; Force encryption insures no connection is established unless both sides
+; support encryption.  By turning this option on, encryption is automatically
+; turned on as well.  The default is no.
+;
+;forceencryption=yes
+;
+
+; This option defines the maximum payload in bytes an IAX2 trunk can support at
+; a given time.  The best way to explain this is to provide an example.  If the
+; maximum number of calls to be supported is 800, and each call transmits 20ms
+; frames of audio using ulaw:
+;
+;     (8000hz / 1000ms) * 20ms * 1 byte per sample = 160 bytes per frame
+;
+; The maximum load in bytes is:
+;
+;     (160 bytes per frame) * (800 calls) = 128000 bytes
+;
+; Once this limit is reached, calls may be dropped or begin to lose audio.
+; Depending on the codec in use and number of channels to be supported this value
+; may need to be raised, but in most cases the default value is large enough.
+;
+; trunkmaxsize = 128000 ; defaults to 128000 bytes, which supports up to 800
+                        ; calls of ulaw at 20ms a frame.
+
+; With a large amount of traffic on IAX2 trunks, there is a risk of bad voice
+; quality when allowing the Linux system to handle fragmentation of UDP packets.
+; Depending on the size of each payload, allowing the OS to handle fragmentation
+; may not be very efficient. This setting sets the maximum transmission unit for
+; IAX2 UDP trunking. The default is 1240 bytes which means if a trunk's payload
+; is over 1240 bytes for every 20ms it will be broken into multiple 1240 byte
+; messages.  Zero disables this functionality and let's the OS handle
+; fragmentation.
+;
+; trunkmtu = 1240    ; trunk data will be sent in 1240 byte messages.
+
+; trunkfreq sets how frequently trunk messages are sent in milliseconds. This
+; value is 20ms by default, which means the trunk will send all the data queued
+; to it in the past 20ms.  By increasing the time between sending trunk messages,
+; the trunk's payload size will increase as well.  Note, depending on the size
+; set by trunkmtu, messages may be sent more often than specified.  For example
+; if a trunk's message size grows to the trunkmtu size before 20ms is reached
+; that message will be sent immediately.  Acceptable values are between 10ms and
+; 1000ms.
+;
+; trunkfreq=20    ; How frequently to send trunk msgs (in ms). This is 20ms by
+                  ; default.
+
+; Should we send timestamps for the individual sub-frames within trunk frames?
+; There is a small bandwidth use for these (less than 1kbps/call), but they
+; ensure that frame timestamps get sent end-to-end properly.  If both ends of
+; all your trunks go directly to TDM, _and_ your trunkfreq equals the frame
+; length for your codecs, you can probably suppress these.  The receiver must
+; also support this feature, although they do not also need to have it enabled.
+;
+; trunktimestamps=yes
+
+; Minimum and maximum amounts of time that IAX2 peers can request as a
+; registration expiration interval (in seconds).
+; minregexpire = 60
+; maxregexpire = 60
+
+; IAX2 helper threads
+
+; Establishes the number of iax helper threads to handle I/O.
+; iaxthreadcount = 10
+
+; Establishes the number of extra dynamic threads that may be spawned to handle I/O
+; iaxmaxthreadcount = 100
+
+;
+; We can register with another IAX2 server to let him know where we are
+; in case we have a dynamic IP address for example
+;
+; Register with tormenta using username marko and password secretpass
+;
+;register => marko:secretpass@tormenta.linux-support.net
+;
+; Register joe at remote host with no password
+;
+;register => joe@remotehost:5656
+;
+; Register marko at tormenta.linux-support.net using RSA key "torkey"
+;
+;register => marko:[torkey]@tormenta.linux-support.net
+;
+; Sample Registration for iaxtel
+;
+; Visit http://www.iaxtel.com to register with iaxtel.  Replace "user"
+; and "pass" with your username and password for iaxtel.  Incoming
+; calls arrive at the "s" extension of "default" context.
+;
+;register => user:pass@iaxtel.com
+;
+; Sample Registration for IAX2 + FWD
+;
+; To register using IAX2 with FWD, it must be enabled by visiting the URL
+; http://www.fwdnet.net/index.php?section_id=112
+;
+; Note that you need an extension in you default context which matches
+; your free world dialup number.  Please replace "FWDNumber" with your
+; FWD number and "passwd" with your password.
+;
+;register => FWDNumber:passwd@iax.fwdnet.net
+;
+; Through the use of the res_stun_monitor module, Asterisk has the ability to detect when the
+; perceived external network address has changed.  When the stun_monitor is installed and
+; configured, chan_iax will renew all outbound registrations when the monitor detects any sort
+; of network change has occurred. By default this option is enabled, but only takes effect once
+; res_stun_monitor is configured.  If res_stun_monitor is enabled and you wish to not
+; generate all outbound registrations on a network change, use the option below to disable
+; this feature.
+;
+; subscribe_network_change_event = yes ; on by default
+;
+; You can enable authentication debugging to increase the amount of
+; debugging traffic.
+;
+;authdebug = yes
+;
+; See https://wiki.asterisk.org/wiki/display/AST/IP+Quality+of+Service for a description of these parameters.
+;tos=ef
+;cos=5
+;
+; If regcontext is specified, Asterisk will dynamically create and destroy
+; a NoOp priority 1 extension for a given peer who registers or unregisters
+; with us.  The actual extension is the 'regexten' parameter of the registering
+; peer or its name if 'regexten' is not provided.  More than one regexten
+; may be supplied if they are separated by '&'.  Patterns may be used in
+; regexten.
+;
+;regcontext=iaxregistrations
+;
+; If we don't get ACK to our NEW within 2000ms, and autokill is set to yes,
+; then we cancel the whole thing (that's enough time for one retransmission
+; only).  This is used to keep things from stalling for a long time for a host
+; that is not available, but would be ill advised for bad connections.  In
+; addition to 'yes' or 'no' you can also specify a number of milliseconds.
+; See 'qualify' for individual peers to turn on for just a specific peer.
+;
+autokill=yes
+;
+; codecpriority controls the codec negotiation of an inbound IAX2 call.
+; This option is inherited to all user entities.  It can also be defined
+; in each user entity separately which will override the setting in general.
+;
+; The valid values are:
+;
+; caller   - Consider the callers preferred order ahead of the host's.
+; host     - Consider the host's preferred order ahead of the caller's.
+; disabled - Disable the consideration of codec preference altogether.
+;            (this is the original behaviour before preferences were added)
+; reqonly  - Same as disabled, only do not consider capabilities if
+;            the requested format is not available the call will only
+;            be accepted if the requested format is available.
+;
+; The default value is 'host'
+;
+;codecpriority=host
+;
+; allowfwdownload controls whether this host will serve out firmware to
+; IAX2 clients which request it.  This has only been used for the IAXy,
+; and it has been recently proven that this firmware distribution method
+; can be used as a source of traffic amplification attacks.  Also, the
+; IAXy firmware has not been updated for at least 18 months, so unless
+; you are provisioning IAXys in a secure network, we recommend that you
+; leave this option to the default, off.
+;
+;allowfwdownload=yes
+
+;rtcachefriends=yes ; Cache realtime friends by adding them to the internal list
+                    ; just like friends added from the config file only on a
+                    ; as-needed basis? (yes|no)
+
+;rtsavesysname=yes  ; Save systemname in realtime database at registration
+                    ; Default = no
+
+;rtupdate=yes       ; Send registry updates to database using realtime? (yes|no)
+                    ; If set to yes, when a IAX2 peer registers successfully,
+                    ; the IP address, the origination port, the registration period,
+                    ; and the username of the peer will be set to database via realtime.
+                    ; If not present, defaults to 'yes'.
+
+;rtautoclear=yes    ; Auto-Expire friends created on the fly on the same schedule
+                    ; as if it had just registered? (yes|no|<seconds>)
+                    ; If set to yes, when the registration expires, the friend will
+                    ; vanish from the configuration until requested again.
+                    ; If set to an integer, friends expire within this number of
+                    ; seconds instead of the registration interval.
+
+;rtignoreregexpire=yes ; When reading a peer from Realtime, if the peer's registration
+                       ; has expired based on its registration interval, used the stored
+                       ; address information regardless. (yes|no)
+
+;parkinglot=edvina     ; Default parkinglot for IAX2 peers and users
+                       ; This can also be configured per device
+                       ; Parkinglots are defined in features.conf
+
+;
+; The following two options are used to disable call token validation for the
+; purposes of interoperability with IAX2 endpoints that do not yet support it.
+;
+; Call token validation can be set as optional for a single IP address or IP
+; address range by using the 'calltokenoptional' option. 'calltokenoptional' is
+; only a global option.
+;
+;calltokenoptional=209.16.236.73/255.255.255.0
+;
+; By setting 'requirecalltoken=no', call token validation becomes optional for
+; that peer/user.  By setting 'requirecalltoken=auto', call token validation
+; is optional until a call token supporting peer registers successfully using
+; call token validation.  This is used as an indication that from now on, we
+; can require it from this peer.  So, requirecalltoken is internally set to yes.
+; requirecalltoken may only be used in peer/user/friend definitions,
+; not in the global scope.
+; By default, 'requirecalltoken=yes'.
+;
+;requirecalltoken=no
+;
+
+;
+; These options are used to limit the amount of call numbers allocated to a
+; single IP address.  Before changing any of these values, it is highly encouraged
+; to read the user guide associated with these options first.  In most cases, the
+; default values for these options are sufficient.
+;
+; The 'maxcallnumbers' option limits the amount of call numbers allowed for each
+; individual remote IP address.  Once an IP address reaches it's call number
+; limit, no more new connections are allowed until the previous ones close.  This
+; option can be used in a peer definition as well, but only takes effect for
+; the IP of a dynamic peer after it completes registration.
+;
+;maxcallnumbers=512
+;
+; The 'maxcallnumbers_nonvalidated' is used to set the combined number of call
+; numbers that can be allocated for connections where call token  validation
+; has been disabled.  Unlike the 'maxcallnumbers' option, this limit is not
+; separate for each individual IP address.  Any connection resulting in a
+; non-call token validated call number being allocated contributes to this
+; limit.  For use cases, see the call token user guide.  This option's
+; default value of 8192 should be sufficient in most cases.
+;
+;maxcallnumbers_nonvalidated=1024
+;
+; The [callnumberlimits] section allows custom call number limits to be set
+; for specific IP addresses and IP address ranges.  These limits take precedence
+; over the global 'maxcallnumbers' option, but may still be overridden by a
+; peer defined 'maxcallnumbers' entry.  Note that these limits take effect
+; for every individual address within the range, not the range as a whole.
+;
+;[callnumberlimits]
+;10.1.1.0/255.255.255.0 = 24
+;10.1.2.0/255.255.255.0 = 32
+;
+
+; The shrinkcallerid function removes '(', ' ', ')', non-trailing '.', and '-' not
+; in square brackets.  For example, the Caller*ID value 555.5555 becomes 5555555
+; when this option is enabled.  Disabling this option results in no modification
+; of the Caller*ID value, which is necessary when the Caller*ID represents something
+; that must be preserved.  This option can only be used in the [general] section.
+; By default this option is on.
+;
+;shrinkcallerid=yes     ; on by default
+


### PR DESCRIPTION
As promised, enhanced the SIP device management to also handle IAX devices.

In config.pp, create a concat instance, to manage the iax.conf file, and add a exec statement, in order to reload the iax config if needed.

Further, updated the config/device.pp, updated a bunch of comments, to reflect that it is now able to also manage iax devices. I only added one additional parameter, to the .pp file and the template, for the IAX handling, the one I currently use and need. There might be more IAX specific parameters, but I thought, whenever someone else might require it, its easy to add later on.

The template file for the iax.conf is taken from the asterisk 11.14.1 version, that I use and where I tested against.
