### PR TITLE
Allow SIP registration to upstream SIP provider

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,6 +35,7 @@ class asterisk::config (
   $manager_enabled,
   $manager_port,
   $manager_webenabled,
+  $register_sip,
   $rtpstart,
   $rtpend,
   $udpbindaddr,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,6 +144,11 @@
 #   Options: 'yes', 'no'
 #   Default: 'no'
 #
+# [*register_sip*]
+#   String. When acting as SIP client to an upstream SIP provider or other asterisk, this is the 
+#   registration string.
+#   Default: ''
+#
 # [*rtpstart*]
 #   String. Lower limit for RTP port range
 #   Default: 10000
@@ -261,6 +266,7 @@ class asterisk(
   $manager_enabled          = $asterisk::params::manager_enabled,
   $manager_port             = $asterisk::params::manager_port,
   $manager_webenabled       = $asterisk::params::manager_webenabled,
+  $register_sip             = $asterisk::params::register_sip,
   $rtpstart                 = $asterisk::params::rtpstart,
   $rtpend                   = $asterisk::params::rtpend,
   $udpbindaddr              = $asterisk::params::udpbindaddr,
@@ -322,6 +328,7 @@ class asterisk(
     manager_enabled     => $manager_enabled,
     manager_port        => $manager_port,
     manager_webenabled  => $manager_webenabled,
+    register_sip	=> $register_sip,
     rtpstart            => $rtpstart,
     rtpend              => $rtpend,
     udpbindaddr         => $udpbindaddr,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class asterisk::params {
   $manager_enabled     = 'no'
   $manager_port        = '5038'
   $manager_webenabled  = 'no'
+  $register_sip        = ''
   $rtpstart            = '10000'
   $rtpend              = '20000'
   $udpbindaddr         = '0.0.0.0'

--- a/templates/sip.conf.erb
+++ b/templates/sip.conf.erb
@@ -688,7 +688,9 @@ tlsdontverifyserver=<%= @tlsdontverifyserver %>
 ;     This will pass incoming calls to the 's' extension
 ;
 ;
-;register => 2345:password@sip_proxy/1234
+<% if @register_sip != '' -%>
+register => <%= @register_sip %>
+<% end -%>
 ;
 ;    Register 2345 at sip provider 'sip_proxy'.  Calls from this provider
 ;    connect to local extension 1234 in extensions.conf, default context,


### PR DESCRIPTION
I use sipgate.de as upstream VoIP provider. 
To connect my asterisk to it, I have, additionally to configure upstream as a "SIP device", to set a register string in the [general] section in sip.conf.

Since I haven't seen another way to accomplish this, this patch allows me to do just that.
The additional parameter I set to $register_sip, defaulting to '' being empty. In that 
case the register => line in sip.conf will not be set. Following the pattern of other
variables used in that file.

Hope this is OK, or otherwise feedback appreciated.

cheers,
Sebastian
