### PR TITLE
Allow multiple register => strings in the sip.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ TCP Port for the Asterisk Manager Interface (AMI) ('5038').
 
 Web Enable the Asterisk Manager Interface (AMI) ('yes' or 'no').
 
+#####`register_sip`
+
+Registration information to upstream SIP devices or providers.
+Either a string, or array of multiple registration strings.
+Defaults as empty string ''.
+
 #####`rtpstart`
 
 Lower limit for RTP port range.

--- a/templates/sip.conf.erb
+++ b/templates/sip.conf.erb
@@ -688,7 +688,11 @@ tlsdontverifyserver=<%= @tlsdontverifyserver %>
 ;     This will pass incoming calls to the 's' extension
 ;
 ;
-<% if @register_sip != '' -%>
+<% if @register_sip.is_a? Array -%>
+<%- @register_sip.each do |reg| -%>
+register => <%= reg %>
+<%- end -%>
+<% elsif @register_sip != '' -%>
 register => <%= @register_sip %>
 <% end -%>
 ;


### PR DESCRIPTION
As it was thought of in the initial request to allow setting register => line in sip.conf, 
this patch allows to set multiple register => strings in sip.conf ;)

It's backward compatible with what is there right now. 
The user either specifies the registration string, or an array of registration
strings.
Depending on either Array or String, the template takes care.

While there, added some documentation to the README.md about that
parameter.

cheers,
Sebastian
