### PR TITLE
Fix sip disallow

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -167,6 +167,16 @@ class asterisk::config (
       order   => '5',
     }
 
+    # Voicemail configuration
+    concat {"${astetcdir}/voicemail.conf":
+      notify => Exec['asterisk-sip-reload'],
+    }
+    concat::fragment { 'voicemail_general':
+      target  => "${astetcdir}/voicemail.conf",
+      content => template('asterisk/voicemail.conf.erb'),
+      order   => '10',
+    }
+
     # TODO /etc/init.d/asterisk
     # TODO /etc/logrotate.d/asterisk
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -194,7 +194,7 @@ class asterisk::config (
   }
 
   # Ask Asterisk to reload the voicemail configuration
-  exec { 'asterisk-iax-reload':
+  exec { 'asterisk-voicemail-reload':
     command     => "${astbinary} -rx 'voicemail reload'",
     refreshonly => true,
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -169,7 +169,7 @@ class asterisk::config (
 
     # Voicemail configuration
     concat {"${astetcdir}/voicemail.conf":
-      notify => Exec['asterisk-sip-reload'],
+      notify => Exec['asterisk-voicemail-reload'],
     }
     concat::fragment { 'voicemail_general':
       target  => "${astetcdir}/voicemail.conf",
@@ -190,6 +190,12 @@ class asterisk::config (
   # Ask Asterisk to reload the IAX configuration
   exec { 'asterisk-iax-reload':
     command     => "${astbinary} -rx 'reload chan_iax2.so'",
+    refreshonly => true,
+  }
+
+  # Ask Asterisk to reload the voicemail configuration
+  exec { 'asterisk-iax-reload':
+    command     => "${astbinary} -rx 'voicemail reload'",
     refreshonly => true,
   }
 }

--- a/manifests/config/voicemail.pp
+++ b/manifests/config/voicemail.pp
@@ -1,30 +1,21 @@
-# == Defined Type: asterisk::config::device
-#  Define SIP and IAX devices for use with Asterisk using concat::fragment on
-#  the sip.conf, or iax.conf file.
+# == Defined Type: asterisk::config::voicemail
+#  Define voicemails for use with Asterisk using concat::fragment on
+#  the vaoicemail.conf file.
 #
 # === Parameters
-#  [*device_name*]
-#    String. Name of the device.
+#  [*id*]
+#    String. Voicemail id
 #    REQUIRED. No Default.
 #
 #  [*target*]
-#    String. Path to sip.conf.
+#    String. Path to voicemail.conf.
 #    REQUIRED. No Default.
-#
-#  [*type*]
-#    String. Values: 'friend', 'peer', or 'user'
-#    Default: 'friend'
-#
-# ==== Array Parameters
-#  [*allow*, *disallow*, *deny*, *permit*]
-#    Array of Strings. IPs or hostnames to control access.
-#    Default: []
 #
 # ==== String Parameters
 #  The remaining parameters are strings as described in the Asterisk
-#  manuals for sip or iax devices.
+#  manuals for voicemails.
 #
-define asterisk::config::device (
+define asterisk::config::voicemail (
   $target,
   $id = $title,
   $password = '',

--- a/manifests/config/voicemail.pp
+++ b/manifests/config/voicemail.pp
@@ -19,7 +19,7 @@ define asterisk::config::voicemail (
   $target,
   $id = $title,
   $password = '',
-  $name = '',
+  $username = '',
   $mail = '',
   $pager = '',
   $options = '',

--- a/manifests/config/voicemail.pp
+++ b/manifests/config/voicemail.pp
@@ -1,0 +1,45 @@
+# == Defined Type: asterisk::config::device
+#  Define SIP and IAX devices for use with Asterisk using concat::fragment on
+#  the sip.conf, or iax.conf file.
+#
+# === Parameters
+#  [*device_name*]
+#    String. Name of the device.
+#    REQUIRED. No Default.
+#
+#  [*target*]
+#    String. Path to sip.conf.
+#    REQUIRED. No Default.
+#
+#  [*type*]
+#    String. Values: 'friend', 'peer', or 'user'
+#    Default: 'friend'
+#
+# ==== Array Parameters
+#  [*allow*, *disallow*, *deny*, *permit*]
+#    Array of Strings. IPs or hostnames to control access.
+#    Default: []
+#
+# ==== String Parameters
+#  The remaining parameters are strings as described in the Asterisk
+#  manuals for sip or iax devices.
+#
+define asterisk::config::device (
+<%= id %> => <%= password %>,<%= name %>,<%= mail %>,<%= pager %>,<%= options %>
+  $target,
+  $id = $title,
+  $password = '',
+  $name = '',
+  $mail = '',
+  $pager = '',
+  $options = '',
+)
+{
+  validate_string ($target, $id, $password)
+
+  concat::fragment{"voicemail_${id}":
+    target  => $target,
+    content => template('asterisk/voicemail.erb'),
+    order   => '50',
+  }
+}

--- a/manifests/config/voicemail.pp
+++ b/manifests/config/voicemail.pp
@@ -25,7 +25,6 @@
 #  manuals for sip or iax devices.
 #
 define asterisk::config::device (
-<%= id %> => <%= password %>,<%= name %>,<%= mail %>,<%= pager %>,<%= options %>
   $target,
   $id = $title,
   $password = '',

--- a/templates/device.erb
+++ b/templates/device.erb
@@ -3,6 +3,9 @@ type = <%= @type %>
 <% if @accountcode != "" -%>
 accountcode = <%= @accountcode %>
 <% end -%>
+<% Array(@disallow).each do |a| -%>
+disallow = <%= a %>
+<% end -%>
 <% Array(@allow).each do |a| -%>
 allow = <%= a %>
 <% end -%>
@@ -65,9 +68,6 @@ directmediadeny = <%= @directmediadeny %>
 <% end -%>
 <% if @directmediapermit != "" -%>
 directmediapermit = <%= @directmediapermit %>
-<% end -%>
-<% Array(@disallow).each do |a| -%>
-disallow = <%= a %>
 <% end -%>
 <% if @dtmfmode != "" -%>
 dtmfmode = <%= @dtmfmode %>

--- a/templates/voicemail.conf.erb
+++ b/templates/voicemail.conf.erb
@@ -1,0 +1,419 @@
+;
+; Voicemail Configuration
+;
+
+;
+; NOTE: Asterisk has to edit this file to change a user's password.  This does
+; not currently work with the "#include <file>" directive for Asterisk
+; configuration files, nor when using realtime static configuration.
+; Do not use them with this configuration file.
+;
+
+[general]
+; Formats for writing Voicemail.  Note that when using IMAP storage for
+; voicemail, only the first format specified will be used.
+;format=g723sf|wav49|wav
+format=wav49|gsm|wav
+;
+; WARNING:
+; If you change the list of formats that you record voicemail in
+; when you have mailboxes that contain messages, you _MUST_ absolutely
+; manually go through those mailboxes and convert/delete/add the
+; the message files so that they appear to have been stored using
+; your new format list. If you don't do this, very unpleasant
+; things may happen to your users while they are retrieving and
+; manipulating their voicemail.
+;
+; In other words: don't change the format list on a production system
+; unless you are _VERY_  sure that you know what you are doing and are
+; prepared for the consequences.
+;
+; Who the e-mail notification should appear to come from
+serveremail=asterisk
+;serveremail=asterisk@linux-support.net
+; Should the email contain the voicemail as an attachment
+attach=yes
+; Maximum number of messages per folder.  If not specified, a default value
+; (100) is used.  Maximum value for this option is 9999.  If set to 0, a
+; mailbox will be greetings-only.
+;maxmsg=100
+; Maximum length of a voicemail message in seconds
+;maxsecs=180
+; Minimum length of a voicemail message in seconds for the message to be kept
+; The default is no minimum.
+;minsecs=3
+; Maximum length of greetings in seconds
+;maxgreet=60
+; How many milliseconds to skip forward/back when rew/ff in message playback
+skipms=3000
+; How many seconds of silence before we end the recording
+maxsilence=10
+; Silence threshold (what we consider silence: the lower, the more sensitive)
+silencethreshold=128
+; Max number of failed login attempts
+maxlogins=3
+;
+; Move heard messages to the 'Old' folder automagically.  Defaults to on.
+;moveheard=yes
+;
+; Forward an urgent message as an urgent message.  Defaults to no so
+; sender can set the urgency on the envelope of the forwarded message.
+;forward_urgent_auto=no
+;
+; User context is where entries from users.conf are registered.  The
+; default value is 'default'
+;
+;userscontext=default
+;
+; If you need to have an external program, i.e. /usr/bin/myapp
+; called when a voicemail is left, delivered, or your voicemailbox
+; is checked, uncomment this.
+;externnotify=/usr/bin/myapp
+
+; If you would also like to enable SMDI notification then set smdienable to yes.
+; You will also need to make sure smdiport is set to a valid port as specified in
+; smdi.conf.
+;smdienable=yes
+;smdiport=/dev/ttyS0
+
+; If you need to have an external program, i.e. /usr/bin/myapp
+; called when a voicemail password is changed, uncomment this. The
+; arguments passed to the application are: <context> <mailbox> <newpassword>
+; Note: If this is set, the password will NOT be changed in voicemail.conf
+; If you would like to also change the password in voicemail.conf, use
+; the externpassnotify option below instead.
+;externpass=/usr/bin/myapp
+;externpassnotify=/usr/bin/myapp
+
+; If you would like to have an external program called when a user changes the
+; voicemail password for the purpose of doing validation on the new password,
+; then use this option.  The script can decide whether or not the new password
+; meets minimum password strength requirements before the Voicemail application
+; accepts the password.  If the script decides that the password is not acceptable,
+; the user will be informed that the new password does not meet minimum password
+; requirements, and they will be asked to enter another password.
+;
+; The arguments passed to this script are <mailbox> <context> <old pw> <new pw>.
+;
+; The script should print "VALID" to stdout to indicate that the new password
+; is acceptable.  If the password is considered too weak, the script should print
+; "INVALID" to stdout.
+;
+; There is an example script in the contrib/scripts/ directory, voicemailpwcheck.py,
+; which implements some basic password checking, and can be used as a starting point
+; for use with this option.
+;
+;externpasscheck=/usr/local/bin/voicemailpwcheck.py
+
+; For the directory, you can override the intro file if you want
+;directoryintro=dir-intro
+; The character set for voicemail messages can be specified here
+; default: ISO-8859-1
+;charset=UTF-8
+; The ADSI feature descriptor number to download to
+;adsifdn=0000000F
+; The ADSI security lock code
+;adsisec=9BDBF7AC
+; The ADSI voicemail application version number.
+;adsiver=1
+; Skip the "[PBX]:" string from the message title
+;pbxskip=yes
+; Change the From: string
+;fromstring=The Asterisk PBX
+; Permit finding entries for forward/compose from the directory
+;usedirectory=yes
+; Voicemail can be stored in a database using the ODBC driver.
+; The value of odbcstorage is the database connection configured
+; in res_odbc.conf.
+;odbcstorage=asterisk
+; The default table for ODBC voicemail storage is voicemessages.
+;odbctable=voicemessages
+;
+; Change the from, body and/or subject, variables:
+;     VM_NAME, VM_DUR, VM_MSGNUM, VM_MAILBOX, VM_CALLERID, VM_CIDNUM,
+;     VM_CIDNAME, VM_DATE
+; Additionally, on forwarded messages, you have the variables:
+;     ORIG_VM_CALLERID, ORIG_VM_CIDNUM, ORIG_VM_CIDNAME, ORIG_VM_DATE
+; You can select between two variables by using dialplan functions, e.g.
+;     ${IF(${ISNULL(${ORIG_VM_DATE})}?${VM_DATE}:${ORIG_VM_DATE})}
+;
+; Note: The emailbody config row can only be up to 512 characters due to a
+;       limitation in the Asterisk configuration subsystem.
+;emailsubject=[PBX]: New message ${VM_MSGNUM} in mailbox ${VM_MAILBOX}
+; The following definition is very close to the default, but the default shows
+; just the CIDNAME, if it is not null, otherwise just the CIDNUM, or "an unknown
+; caller", if they are both null.
+;emailbody=Dear ${VM_NAME}:\n\n\tjust wanted to let you know you were just left a ${VM_DUR} long message (number ${VM_MSGNUM})\nin mailbox ${VM_MAILBOX} from ${VM_CALLERID}, on ${VM_DATE}, so you might\nwant to check it when you get a chance.  Thanks!\n\n\t\t\t\t--Asterisk\n
+;
+; Note: ${IF()} strips spacing at the beginning and end of its true and false
+; values, so a newline cannot be placed at either location.  The word 'so' is
+; therefore duplicated, in order for the newline to be interpreted correctly.
+;emailbody=Dear ${VM_NAME}:\n\n\tjust wanted to let you know you were just ${IF($["${VM_CIDNUM}" = "${ORIG_VM_CIDNUM}"]?left:forwarded)} a ${VM_DUR} long message (number ${VM_MSGNUM})\nin mailbox ${VM_MAILBOX} from ${VM_CALLERID}, on ${VM_DATE},\n${IF($["${VM_CIDNUM}" = "${ORIG_VM_CIDNUM}"]?so:(originally sent by ${ORIG_VM_CALLERID} on ${ORIG_VM_DATE})\nso)} you might want to check it when you get a chance.  Thanks!\n\n\t\t\t\t--Asterisk\n
+;
+; You can also change the Pager From: string, the pager body and/or subject.
+; The above defined variables also can be used here
+;pagerfromstring=The Asterisk PBX
+;pagersubject=New VM
+;pagerbody=New ${VM_DUR} long msg in box ${VM_MAILBOX}\nfrom ${VM_CALLERID}, on ${VM_DATE}
+;
+; Set the date format on outgoing mails. Valid arguments can be found on the
+; strftime(3) man page
+;
+; Default
+emaildateformat=%A, %B %d, %Y at %r
+; 24h date format
+;emaildateformat=%A, %d %B %Y at %H:%M:%S
+;
+; Default for pager use
+pagerdateformat=%A, %B %d, %Y at %r
+; Short 24h date format for pager use
+;pagerdateformat=%T %D
+;
+; You can override the default program to send e-mail if you wish, too
+;
+;mailcmd=/usr/sbin/sendmail -t
+;
+;pollmailboxes=no    ;   If mailboxes are changed anywhere outside of app_voicemail,
+;                    ; then this option must be enabled for MWI to work.  This
+;                    ; enables polling mailboxes for changes.  Normally, it will
+;                    ; expect that changes are only made when someone called in
+;                    ; to one of the voicemail applications.
+;                    ;   Examples of situations that would require this option are
+;                    ; web interfaces to voicemail or an email client in the case
+;                    ; of using IMAP storage.
+;                    ; Default: no
+;pollfreq=30         ;   If the "pollmailboxes" option is enabled, this option
+;                    ; sets the polling frequency.  The default is once every
+;                    ; 30 seconds.
+; If using IMAP storage, specify whether voicemail greetings should be stored
+; via IMAP. If no, then greetings are stored as if IMAP storage were not enabled
+;imapgreetings=no
+; If imapgreetings=yes, then specify which folder to store your greetings in. If
+; you do not specify a folder, then INBOX will be used
+;greetingsfolder=INBOX
+; Some IMAP server implementations store folders under INBOX instead of
+; using a top level folder (ex. INBOX/Friends).  In this case, user
+; imapparentfolder to set the parent folder. For example, Cyrus IMAP does
+; NOT use INBOX as the parent. Default is to have no parent folder set.
+;imapparentfolder=INBOX
+;
+;
+;
+; Each mailbox is listed in the form <mailbox>=<password>,<name>,<email>,<pager_email>,<options>
+; if the e-mail is specified, a message will be sent when a message is
+; received, to the given mailbox. If pager is specified, a message will be
+; sent there as well. If the password is prefixed by '-', then it is
+; considered to be unchangeable.
+;
+; Advanced options example is extension 4069
+; NOTE: All options can be expressed globally in the general section, and
+; overridden in the per-mailbox settings, unless listed otherwise.
+;
+; tz=central 		; Timezone from zonemessages below. Irrelevant if envelope=no.
+; locale=de_DE.UTF-8	; set the locale for generation of the date/time strings (make 
+			; sure the locales are installed in your operating system; e.g
+			; on Debian Linux you can use "dpkg-reconfigure locales").
+			; If you use UTF-8 locales, make sure to set the "charset" option
+			; to UTF-8 too. If you mix different locales for different users
+			; you should avoid words in the emaildateformat specification, e.g.:
+			; emaildateformat=%A, %d %B %Y, %H:%M:%S
+; attach=yes 		; Attach the voicemail to the notification email *NOT* the pager email
+; attachfmt=wav49	; Which format to attach to the email.  Normally this is the
+			; first format specified in the format parameter above, but this
+			; option lets you customize the format sent to particular mailboxes.
+			; Useful if Windows users want wav49, but Linux users want gsm.
+			; [per-mailbox only]
+; saycid=yes 		; Say the caller id information before the message. If not described,
+			;     or set to no, it will be in the envelope
+; cidinternalcontexts=intern	; Internal Context for Name Playback instead of
+			; extension digits when saying caller id.
+; sayduration=no 	; Turn on/off the duration information before the message. [ON by default]
+; saydurationm=2        ; Specify the minimum duration to say. Default is 2 minutes
+; dialout=fromvm ; Context to dial out from [option 4 from mailbox's advanced menu].
+                 ; If not specified, option 4 will not be listed and dialing out
+                 ; from within VoiceMailMain() will not be permitted.
+sendvoicemail=yes ; Allow the user to compose and send a voicemail while inside
+                  ; VoiceMailMain() [option 5 from mailbox's advanced menu].
+                  ; If set to 'no', option 5 will not be listed.
+; searchcontexts=yes	; Current default behavior is to search only the default context
+			; if one is not specified.  The older behavior was to search all contexts.
+			; This option restores the old behavior [DEFAULT=no]
+			; Note: If you have this option enabled, then you will be required to have
+			; unique mailbox names across all contexts. Otherwise, an ambiguity is created
+			; since it is impossible to know which mailbox to retrieve when one is requested.
+; callback=fromvm 	; Context to call back from
+			;     if not listed, calling the sender back will not be permitted
+; exitcontext=fromvm    ; Context to go to on user exit such as * or 0
+                        ;     The default is the current context.
+; review=yes 		; Allow sender to review/rerecord their message before saving it [OFF by default
+; operator=yes      ; Allow sender to hit 0 before/after/during leaving a voicemail to
+                    ; reach an operator.  This option REQUIRES an 'o' extension in the
+                    ; same context (or in exitcontext, if set), as that is where the
+                    ; 0 key will send you.  [OFF by default]
+; envelope=no 		; Turn on/off envelope playback before message playback. [ON by default]
+			;     This does NOT affect option 3,3 from the advanced options menu
+; delete=yes		; After notification, the voicemail is deleted from the server. [per-mailbox only]
+			;     This is intended for use with users who wish to receive their
+			;     voicemail ONLY by email. Note:  "deletevoicemail" is provided as an
+			;     equivalent option for Realtime configuration.
+; volgain=0.0		; Emails bearing the voicemail may arrive in a volume too
+			;     quiet to be heard.  This parameter allows you to specify how
+			;     much gain to add to the message when sending a voicemail.
+			;     NOTE: sox must be installed for this option to work.
+; nextaftercmd=yes	; Skips to the next message after hitting 7 or 9 to delete/save current message.
+; forcename=yes		; Forces a new user to record their name.  A new user is
+			;     determined by the password being the same as
+			;     the mailbox number.  The default is "no".
+; forcegreetings=no	; This is the same as forcename, except for recording
+			;     greetings.  The default is "no".
+; hidefromdir=yes	; Hide this mailbox from the directory produced by app_directory
+			;     The default is "no".
+; tempgreetwarn=yes	; Remind the user that their temporary greeting is set
+
+; passwordlocation=spooldir
+                    ; Usually the voicemail password (vmsecret) is stored in
+                    ; this configuration file.  By setting this option you can
+                    ; specify where Asterisk should read/write the vmsecret.
+                    ; Supported options:
+                    ;   voicemail.conf:
+                    ;     This is the default option.  The secret is read from
+                    ;     and written to voicemail.conf (or users.conf).
+                    ;   spooldir:
+                    ;     The secret is stored in a separate file in the user's
+                    ;     voicemail spool directory in a file named secret.conf.
+                    ;     Please ensure that normal Linux users are not
+                    ;     permitted to access Asterisk's spool directory as the
+                    ;     secret is stored in plain text.  If a secret is not
+                    ;     found in this directory, the password in
+                    ;     voicemail.conf (or users.conf) will be used.
+                    ; Note that this option does not affect password storage for
+                    ; realtime users, which are still stored in the realtime
+                    ; backend.
+; messagewrap=no    ; Enable next/last message to wrap around to
+                    ; first (from last) and last (from first) message
+                    ; The default is "no".
+; minpassword=0 ; Enforce minimum password length
+
+; vm-password=custom_sound
+			;     Customize which sound file is used instead of the default
+			;     prompt that says: "password"
+; vm-newpassword=custom_sound
+			;     Customize which sound file is used instead of the default
+			;     prompt that says: "Please enter your new password followed by
+			;     the pound key."
+; vm-passchanged=custom_sound
+			;     Customize which sound file is used instead of the default
+			;     prompt that says: "Your password has been changed."
+; vm-reenterpassword=custom_sound
+			;     Customize which sound file is used instead of the default
+			;     prompt that says: "Please re-enter your password followed by
+			;     the pound key"
+; vm-mismatch=custom_sound
+			;     Customize which sound file is used instead of the default
+			;     prompt that says: "The passwords you entered and re-entered
+			;     did not match."
+; vm-invalid-password=custom_sound
+			;     Customize which sound file is used instead of the default
+			;     prompt that says: ...
+; vm-pls-try-again=custom_sound
+                        ; Customize which sound file is used instead of the
+                        ; default prompt that says "Please try again."
+; vm-prepend-timeout=custom_sound
+                        ; Customize which sound file is used when the user
+                        ; times out while recording a prepend message instead
+                        ; of the default prompt that says "then press pound"
+                        ; note that this will currently follow vm-pls-try-again.
+                        ; this behavior is subject to change in the near future.
+; listen-control-forward-key=#	; Customize the key that fast-forwards message playback
+; listen-control-reverse-key=*	; Customize the key that rewinds message playback
+; listen-control-pause-key=0	; Customize the key that pauses/unpauses message playback
+; listen-control-restart-key=2	; Customize the key that restarts message playback
+; listen-control-stop-key=13456789	; Customize the keys that interrupt message playback, probably all keys not set above
+
+; Maximum number of messages allowed in the 'Deleted' folder. If set to 0
+; or no then no deleted messages will be moved. If non-zero (max 9999) then up
+; to this number of messages will be automagically saved when they are
+; 'deleted' on a FIFO basis.
+; defaults to being off
+; backupdeleted=100
+
+
+[zonemessages]
+; Users may be located in different timezones, or may have different
+; message announcements for their introductory message when they enter
+; the voicemail system. Set the message and the timezone each user
+; hears here. Set the user into one of these zones with the tz= attribute
+; in the options field of the mailbox. Of course, language substitution
+; still applies here so you may have several directory trees that have
+; alternate language choices.
+;
+; Look in /usr/share/zoneinfo/ for names of timezones.
+; Look at the manual page for strftime for a quick tutorial on how the
+; variable substitution is done on the values below.
+;
+; Supported values:
+; 'filename'    filename of a soundfile (single ticks around the filename
+;               required)
+; ${VAR}        variable substitution
+; A or a        Day of week (Saturday, Sunday, ...)
+; B or b or h   Month name (January, February, ...)
+; d or e        numeric day of month (first, second, ..., thirty-first)
+; Y             Year
+; I or l        Hour, 12 hour clock
+; H             Hour, 24 hour clock (single digit hours preceded by "oh")
+; k             Hour, 24 hour clock (single digit hours NOT preceded by "oh")
+; M             Minute, with 00 pronounced as "o'clock"
+; N             Minute, with 00 pronounced as "hundred" (US military time)
+; P or p        AM or PM
+; Q             "today", "yesterday" or ABdY
+;               (*note: not standard strftime value)
+; q             "" (for today), "yesterday", weekday, or ABdY
+;               (*note: not standard strftime value)
+; R             24 hour time, including minute
+;
+eastern=America/New_York|'vm-received' Q 'digits/at' IMp
+central=America/Chicago|'vm-received' Q 'digits/at' IMp
+central24=America/Chicago|'vm-received' q 'digits/at' H N 'hours'
+military=Zulu|'vm-received' q 'digits/at' H N 'hours' 'phonetic/z_p'
+european=Europe/Copenhagen|'vm-received' a d b 'digits/at' HM
+
+
+
+[default]
+
+;1234 => 4242,Example Mailbox,root@localhost
+;4200 => 9855,Mark Spencer,markster@linux-support.net,mypager@digium.com,attach=no|serveremail=myaddy@digium.com|tz=central|maxmsg=10
+;4300 => 3456,Ben Rigas,ben@american-computer.net
+;4310 => -5432,Sales,sales@marko.net
+;4069 => 6522,Matt Brooks,matt@marko.net,,|tz=central|attach=yes|saycid=yes|dialout=fromvm|callback=fromvm|review=yes|operator=yes|envelope=yes|moveheard=yes|sayduration=yes|saydurationm=1
+;4073 => 1099,Bianca Paige,bianca@biancapaige.com,,delete=1|emailsubject=You have a new voicemail.|emailbody=Click on the attachment to listen.|rip=2010-06-04
+;4110 => 3443,Rob Flynn,rflynn@blueridge.net
+;4235 => 1234,Jim Holmes,jim@astricon.ips,,Tz=european
+
+
+;
+; Mailboxes may be organized into multiple contexts for
+; voicemail virtualhosting
+;
+
+;[other]
+;The intro can be customized on a per-context basis
+;directoryintro=dir-company2
+;1234 => 5678,Company2 User,root@localhost
+
+; example for our acme compartmentalized company
+;
+; Pete telecommutes from Chicago, so we'll customize timestamps for him.
+;
+;[acme]
+;111 => 7383,Pete,pete@acme-widgets.com,,tz=central
+;112 => 6262,Nancy,nancy@acme-widgets.com
+;
+
+;
+; When using IMAP storage, imapuser, imappassword, and imapfolder can be used to specify the
+; user's credentials.
+;
+;[imapvm]
+;4324 => 7764,Ellis Redding,red@buxton.us,,imapuser=eredding|imappassword=g3tbusy|imapfolder=notinbox
+;4325 => 2392,Andrew Dufresne,andy@dufresne.info,,imapuser=adufresne|imappassword=rockh@mmer

--- a/templates/voicemail.erb
+++ b/templates/voicemail.erb
@@ -1,1 +1,1 @@
-<%= id %> => <%= password %>,<%= name %>,<%= mail %>,<%= pager %>,<%= options %>
+<%= id %> => <%= password %>,<%= username %>,<%= mail %>,<%= pager %>,<%= options %>

--- a/templates/voicemail.erb
+++ b/templates/voicemail.erb
@@ -1,0 +1,1 @@
+<%= id %> => <%= password %>,<%= name %>,<%= mail %>,<%= pager %>,<%= options %>


### PR DESCRIPTION
Hi for the last time ;)

I had to swap allow/disallow parameters in the SIP device configuration, mostly because I use "disallow all" and putting it after "allows" resulted in a device with no active codecs.

Of course YMMV, this is just a quick-n-dirty hack.

Bye, Ugo
